### PR TITLE
Lade till översättningar

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ oss.
 
     - Skicka en ryckbegäran när du är färdig med sammanfogningen!
 
-	- Låt oss plocka russin från mäster-grenen.
+    - Låt oss plocka russin från mäster-grenen.
 
 ## Dagligt bruk
 
@@ -71,8 +71,8 @@ kommandon ändrar din `~/.gitconfig` och kommer att verka globalt.
     git config --global alias.forvara stash
     git config --global alias.marke tag
     git config --global alias.mark tag
-	git config --global alias.klona clone
-	git config --global alias.kika checkout
-	git config --global alias.tillagg add
+    git config --global alias.klona clone
+    git config --global alias.kika checkout
+    git config --global alias.tillagg add
 
     alias jävel=git

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ oss.
 | merge       | merga          | sammanfoga    |
 | stash       | stasha         | gömma         |
 | tag         | tagga          | märka         |
+| clone       | clona          | klona         |
+| checkout    | checka ut      | kika          |
+| add         | adda           | lägga till    |
 | cherry-pick | cherry-picka   | plocka russin |
 | amend       | amenda         | rätta till    |
 
@@ -68,5 +71,8 @@ kommandon ändrar din `~/.gitconfig` och kommer att verka globalt.
     git config --global alias.gom stash
     git config --global alias.marke tag
     git config --global alias.mark tag
+	git config --global alias.klona clone
+	git config --global alias.kika checkout
+	git config --global alias.tillagg add
 
     alias jävel=git

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ oss.
 | Substantiv   | Nuvarande bruk | Förslag     |
 |--------------|----------------|-------------|
 | git          | git            | jävel       |
-| repository   | repo           | förvaring   |
+| repository   | repo           | valv        |
 | branch       | branch         | gren        |
 | commit       | commit         | förbindelse |
 | pull request | pull request   | ryckbegäran |
@@ -46,13 +46,13 @@ oss.
 
 ## Exempel
 
-    - Kan du rycka grenen jag just ympade och trycka till github?
+    - Kan du rycka grenen jag just ympade och trycka till fjärrvalvet på github?
 
     - Jag förgrenade alldeles nyss och förband ändringarna från min gömma där.
 
     - Skicka en ryckbegäran när du är färdig med sammanfogningen!
 
-    - Låt oss plocka russin från mäster-grenen.
+	- Låt oss plocka russin från mäster-grenen.
 
 ## Dagligt bruk
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ oss.
 | commit      | commita        | förbinda      |
 | rebase      | rebasa         | ympa          |
 | merge       | merga          | sammanfoga    |
-| stash       | stasha         | gömma         |
+| stash       | stasha         | förvara       |
 | tag         | tagga          | märka         |
 | clone       | clona          | klona         |
 | checkout    | checka ut      | kika          |
@@ -68,7 +68,7 @@ kommandon ändrar din `~/.gitconfig` och kommer att verka globalt.
     git config --global alias.forbinda commit
     git config --global alias.ympa rebase
     git config --global alias.sammanfoga merge
-    git config --global alias.gom stash
+    git config --global alias.forvara stash
     git config --global alias.marke tag
     git config --global alias.mark tag
 	git config --global alias.klona clone


### PR DESCRIPTION
Saknade översättningar för clone, checkout och add.
Översättningar: 
clone -> klona
checkout -> kika
add -> lägga till / tillägga

Dessutom anser jag att valv är en bättre översättning än förvaring för repo och att förvara passar bättre än gömma för stash (verbet)
