### PR TITLE
Lägg till blame -> klandra

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ oss.
 | tag         | tagga          | märka         |
 | cherry-pick | cherry-picka   | plocka russin |
 | amend       | amenda         | rätta till    |
+| blame       | blamea         | klandra       |
 
 | Substantiv   | Nuvarande bruk | Förslag     |
 |--------------|----------------|-------------|

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ kommandon ändrar din `~/.gitconfig` och kommer att verka globalt.
     git config --global alias.ympa rebase
     git config --global alias.sammanfoga merge
     git config --global alias.gom stash
+    git config --global alias.klandra blame
     git config --global alias.marke tag
     git config --global alias.mark tag
 


### PR DESCRIPTION
Jag försökte se vem jag kan klandra för att använda 'jävel' i ett dokument med riktlinjer för arbetsplatsen och insåg att detta saknades.