### PR TITLE
Computer friendly wording + installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ oss.
 | Substantiv   | Nuvarande bruk | Förslag     |
 |--------------|----------------|-------------|
 | git          | git            | git         |
-| repository   | repo           | förvaring   |
+| repository   | repo           | låda        |
 | branch       | branch         | gren        |
 | commit       | commit         | remmitering |
 | pull request | pull request   | ryckbegäran |

--- a/README.md
+++ b/README.md
@@ -57,23 +57,12 @@ oss.
 
     - Mosa dina förbindelser innan du sammanfogar.
 
-## Dagligt bruk
+## Installation
 
-Nedan följer en rad kommandoradskommandon för att sätta upp en svensk
-gitmiljö. Avsaknaden av svenska tecken i täcknamnen beror på en brist i git
-(överväg att förbättra mjukvaran och skicka en ryckbegäran!). Följande
-kommandon ändrar din `~/.gitconfig` och kommer att verka globalt.
+Installera svenska kommandon genom att laddad ner och kör:
 
-    git config --global alias.ryck pull
-    git config --global alias.knuffa push
-    git config --global alias.gren branch
-    git config --global alias.forgrena branch
-    git config --global alias.forbinda commit
-    git config --global alias.ympa rebase
-    git config --global alias.sammanfoga merge
-    git config --global alias.gom stash
-    git config --global alias.klandra blame
-    git config --global alias.marke tag
-    git config --global alias.mark tag
+```
+bash install.sh
+```
 
-    alias jävel=git
+

--- a/README.md
+++ b/README.md
@@ -21,27 +21,27 @@ oss.
 |-------------|----------------|---------------|
 | pull        | pulla          | rycka         |
 | push        | pusha          | knuffa        |
-| fetch       | fetcha         | hämta         |
-| branch      | brancha        | förgrena      |
-| commit      | commita        | förbinda      |
+| fetch       | fetcha         | apportera     |
+| branch      | brancha        | grena         |
+| commit      | commita        | remittera     |
 | rebase      | rebasa         | ympa          |
 | merge       | merga          | sammanfoga    |
 | squash      | squasha        | mosa          |
-| stash       | stasha         | gömma         |
-| tag         | tagga          | märka         |
+| stash       | stasha         | stoppa undan  |
+| tag         | tagga          | lappa         |
 | cherry-pick | cherry-picka   | plocka russin |
-| amend       | amenda         | rätta till    |
+| amend       | amenda         | fixa          |
 | blame       | blamea         | klandra       |
 
 | Substantiv   | Nuvarande bruk | Förslag     |
 |--------------|----------------|-------------|
-| git          | git            | jävel       |
+| git          | git            | git         |
 | repository   | repo           | förvaring   |
 | branch       | branch         | gren        |
-| commit       | commit         | förbindelse |
+| commit       | commit         | remmitering |
 | pull request | pull request   | ryckbegäran |
-| stash        | stash          | gömma       |
-| tag          | tagg           | märke       |
+| stash        | stash          | gömställe   |
+| tag          | tagg           | lapp        |
 
 ## Exempel
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+git config --global alias.ryck pull
+git config --global alias.plus add
+git config --global alias.knuff push
+git config --global alias.gren branch
+git config --global alias.remittera commit
+git config --global alias.ymmpa rebase
+git config --global alias.merge sammanfoga
+git config --global alias.squash mosa
+git config --global alias.stoppa-undan stash
+git config --global alias.lapp tag
+git config --global alias.plocka-russin cherry-pick
+git config --global alias.fixa-till amend
+git config --global alias.klandra blame
+git config --global alias.apportera fetch
+
+FILE=~/.bashrc
+REGEX="^alias git='LANG=.* git'"
+DEST="alias git='LANG=sv_SE git'"
+
+if grep -qe "$REGEX" "$FILE"
+then
+  LINE=$(grep -ne "$REGEX" "$FILE" | cut -d : -f 1)
+  sed -i.bak -e $LINE'd' $FILE
+fi
+echo $DEST >> $FILE
+source $FILE


### PR DESCRIPTION
Updated the wording to be computer friendly and added a bash installer to install the git commands and also change the main language of git to Swedish. 
