### PR TITLE
Uppdatera aliaskommandon till nytt syntax för 2.54.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,20 +60,19 @@ oss.
 ## Dagligt bruk
 
 Nedan följer en rad kommandoradskommandon för att sätta upp en svensk
-gitmiljö. Avsaknaden av svenska tecken i täcknamnen beror på en brist i git
-(överväg att förbättra mjukvaran och skicka en ryckbegäran!). Följande
-kommandon ändrar din `~/.gitconfig` och kommer att verka globalt.
+gitmiljö. Följande kommandon ändrar din `~/.gitconfig` och 
+kommer att verka globalt.
 
-    git config --global alias.ryck pull
-    git config --global alias.knuffa push
-    git config --global alias.gren branch
-    git config --global alias.forgrena branch
-    git config --global alias.forbinda commit
-    git config --global alias.ympa rebase
-    git config --global alias.sammanfoga merge
-    git config --global alias.gom stash
-    git config --global alias.klandra blame
-    git config --global alias.marke tag
-    git config --global alias.mark tag
+    git config --global alias.ryck.command pull
+    git config --global alias.knuffa.command push
+    git config --global alias.gren.command branch
+    git config --global alias.förgrena.command branch
+    git config --global alias.förbind.command commit
+    git config --global alias.ympa.command rebase
+    git config --global alias.sammanfoga.command merge
+    git config --global alias.göm.command stash
+    git config --global alias.klandra.command blame
+    git config --global alias.marke.command tag
+    git config --global alias.mark.command tag
 
     alias jävel=git

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ kommer att verka globalt.
     git config --global alias.sammanfoga.command merge
     git config --global alias.göm.command stash
     git config --global alias.klandra.command blame
-    git config --global alias.marke.command tag
-    git config --global alias.mark.command tag
+    git config --global alias.märke.command tag
+    git config --global alias.märk.command tag
 
     alias jävel=git


### PR DESCRIPTION
Jag skickade en ryckbegäran till jävel.jävel för några månader sedan och lyckades få ett nytt syntax som stödjer samtliga unicodetecken (förutom NUL, nyrad osv) i aliasnamnen. På grund av git-pa-svenska så har RIKTIGA JÄVEL nu alltså bättre stöd för aliasar i version >=2.54.0.

Detta är inte ett sent aprilskämt. Se https://lore.kernel.org/git/xmqqzf3lqpp9.fsf@gitster.g/T/#u